### PR TITLE
Fix PUT for files >= 64KB

### DIFF
--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -8,6 +8,7 @@ Version 1.1.1
 ^^^^^^^^^^^^^
 
 * Fix double-free when using :c:func:`ms3_thread_init` and an error occurs
+* Fix error when a PUT >= 65535 is attempted
 
 Version 1.1.0 GA (2019-03-27)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/request.c
+++ b/src/request.c
@@ -259,14 +259,16 @@ static uint8_t generate_request_hash(uri_method_t method, const char *path,
 static size_t put_callback(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   put_buffer_st *buf = (put_buffer_st *)stream;
+  size_t buffer_size = size * nmemb;
 
+  ms3debug("PUT callback %lu bytes remaining, %lu buffer", buf->length - buf->offset, buffer_size);
   // All data copied
   if (buf->length == buf->offset)
   {
     return 0;
   }
 
-  if (size + nmemb >= buf->length - buf->offset)
+  if (buffer_size >= buf->length - buf->offset)
   {
     size_t transfer = buf->length - buf->offset;
     memcpy(ptr, buf->data + buf->offset, transfer);
@@ -275,9 +277,9 @@ static size_t put_callback(void *ptr, size_t size, size_t nmemb, void *stream)
   }
   else
   {
-    memcpy(ptr, buf->data + buf->offset, size + nmemb);
-    buf->offset += size + nmemb;
-    return size + nmemb;
+    memcpy(ptr, buf->data + buf->offset, buffer_size);
+    buf->offset += buffer_size;
+    return buffer_size;
   }
 
 }
@@ -507,7 +509,7 @@ static size_t body_callback(void *buffer, size_t size,
   mem->length += realsize;
   mem->data[mem->length] = 0;
 
-  ms3debug("%.*s\n", (int)(nitems * size), (char *)buffer);
+  ms3debug("Read %lu bytes, buffer %lu bytes", realsize, mem->length);
   return nitems * size;
 }
 
@@ -554,10 +556,12 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
     free(mem.data);
     free(path);
     free(query);
+
     if (not ms3->curl)
     {
       curl_easy_cleanup(curl);
     }
+
     return res;
   }
 
@@ -586,10 +590,12 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
       free(mem.data);
       free(path);
       free(query);
+
       if (not ms3->curl)
       {
         curl_easy_cleanup(curl);
       }
+
       return MS3_ERR_IMPOSSIBLE;
   }
 
@@ -602,10 +608,12 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
     free(path);
     free(query);
     curl_slist_free_all(headers);
+
     if (not ms3->curl)
     {
       curl_easy_cleanup(curl);
     }
+
     return res;
   }
 
@@ -622,10 +630,12 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
     free(path);
     free(query);
     curl_slist_free_all(headers);
+
     if (not ms3->curl)
     {
       curl_easy_cleanup(curl);
     }
+
     return MS3_ERR_REQUEST_ERROR;
   }
 

--- a/tests/include.am
+++ b/tests/include.am
@@ -26,6 +26,11 @@ t_basic_thread_LDADD= src/libmarias3.la @LIBMHASH_LIB@
 check_PROGRAMS+= t/basic_thread
 noinst_PROGRAMS+= t/basic_thread
 
+t_large_file_SOURCES= tests/large_file.c
+t_large_file_LDADD= src/libmarias3.la @LIBMHASH_LIB@
+check_PROGRAMS+= t/large_file
+noinst_PROGRAMS+= t/large_file
+
 t_prefix_SOURCES= tests/prefix.c
 t_prefix_LDADD= src/libmarias3.la @LIBMHASH_LIB@
 check_PROGRAMS+= t/prefix

--- a/tests/large_file.c
+++ b/tests/large_file.c
@@ -1,0 +1,63 @@
+/* vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
+ * Copyright 2019 MariaDB Corporation Ab. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+#include <yatl/lite.h>
+#include <libmarias3/marias3.h>
+
+/* Tests basic PUT/GET a 64MB file */
+
+int main(int argc, char *argv[])
+{
+  (void) argc;
+  (void) argv;
+  int res;
+  uint8_t *data;
+  size_t length;
+  char *test_string = malloc(64 * 1024 * 1024);
+  memset(test_string, 'a', 64 * 1024 * 1024);
+  char *s3key = getenv("S3KEY");
+  char *s3secret = getenv("S3SECRET");
+  char *s3region = getenv("S3REGION");
+  char *s3bucket = getenv("S3BUCKET");
+  char *s3host = getenv("S3HOST");
+
+  SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
+  SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
+  SKIP_IF_(!s3region, "Environemnt variable S3REGION missing");
+  SKIP_IF_(!s3bucket, "Environemnt variable S3BUCKET missing");
+
+  ms3_library_init();
+  ms3_st *ms3 = ms3_thread_init(s3key, s3secret, s3region, s3host);
+
+//  ms3_debug(true);
+  ASSERT_NOT_NULL(ms3);
+
+  res = ms3_put(ms3, s3bucket, "test/large_file.dat",
+                (const uint8_t *)test_string,
+                64 * 1024 * 1024);
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  res = ms3_get(ms3, s3bucket, "test/large_file.dat", &data, &length);
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  ASSERT_EQ(length, 64 * 1024 * 1024);
+  res = ms3_delete(ms3, s3bucket, "test/large_file.dat");
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  free(test_string);
+  free(data);
+  ms3_deinit(ms3);
+}


### PR DESCRIPTION
We were adding buffers instead of multiplying which meant a return of
65537 bytes when the buffer was only 1 * 65536 bytes.

Fixes #22 