### PR TITLE
Improve third-party S3 API support

### DIFF
--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -4,10 +4,14 @@ Version History
 Version 2.1
 -----------
 
-Version 2.1.1 GA
-^^^^^^^^^^^^^^^^
+Version 2.1.1 GA (2019-04-02)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Remove iso646.h support in codebase
+* Autoswitch to bucket path instead of bucket domain access method (for IP urls)
+* Fixed issue with SSL disabled verification
+* Fixed minor leak when base_domain is set
+* Add ``S3NOVERIFY`` env var to tests which will disable SSL verification when set to ``1``
 
 Version 2.1.0 GA (2019-03-29)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/introduction/compiling.rst
+++ b/docs/introduction/compiling.rst
@@ -31,19 +31,21 @@ libMariaS3 comes with a basic test suite which we recommend executing, especiall
 
 You will need the following OS environment variables set to run the tests:
 
-+----------+------------------------------------------+
-| Variable | Desription                               |
-+==========+==========================================+
-| S3KEY    | Your AWS access key                      |
-+----------+------------------------------------------+
-| S3SECRET | Your AWS secret key                      |
-+----------+------------------------------------------+
-| S3REGION | The AWS region (for example us-east-1)   |
-+----------+------------------------------------------+
-| S3BUCKET | The S3 bucket name                       |
-+----------+------------------------------------------+
-| S3HOST   | OPTIONAL hostname for non-AWS S3 service |
-+----------+------------------------------------------+
++------------+----------------------------------------------------------+
+| Variable   | Desription                                               |
++============+==========================================================+
+| S3KEY      | Your AWS access key                                      |
++------------+----------------------------------------------------------+
+| S3SECRET   | Your AWS secret key                                      |
++------------+----------------------------------------------------------+
+| S3REGION   | The AWS region (for example us-east-1)                   |
++------------+----------------------------------------------------------+
+| S3BUCKET   | The S3 bucket name                                       |
++------------+----------------------------------------------------------+
+| S3HOST     | OPTIONAL hostname for non-AWS S3 service                 |
++------------+----------------------------------------------------------+
+| S3NOVERIFY | Set to ``1`` if the host should not use SSL verification |
++------------+----------------------------------------------------------+
 
 The test suite is automatically built along with the library and can be executed with ``make check`` or ``make distcheck``.  If you wish to test with valgrind you can use::
 

--- a/src/marias3.c
+++ b/src/marias3.c
@@ -78,6 +78,7 @@ void ms3_deinit(ms3_st *ms3)
 
   ms3debug("deinit: 0x%" PRIXPTR, (uintptr_t)ms3);
   free(ms3->region);
+  free(ms3->base_domain);
   curl_easy_cleanup(ms3->curl);
   free(ms3->last_error);
   free(ms3);

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
   char *s3region = getenv("S3REGION");
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
+  char *s3noverify = getenv("S3NOVERIFY");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -45,6 +46,12 @@ int main(int argc, char *argv[])
 
   ms3_library_init();
   ms3_st *ms3 = ms3_thread_init(s3key, s3secret, s3region, s3host);
+
+  if (s3noverify && !strcmp(s3noverify, "1"))
+  {
+    bool option = true;
+    ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, &option);
+  }
 
 //  ms3_debug(true);
   ASSERT_NOT_NULL(ms3);

--- a/tests/large_file.c
+++ b/tests/large_file.c
@@ -36,6 +36,7 @@ int main(int argc, char *argv[])
   char *s3region = getenv("S3REGION");
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
+  char *s3noverify = getenv("S3NOVERIFY");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -44,6 +45,12 @@ int main(int argc, char *argv[])
 
   ms3_library_init();
   ms3_st *ms3 = ms3_thread_init(s3key, s3secret, s3region, s3host);
+
+  if (s3noverify && !strcmp(s3noverify, "1"))
+  {
+    bool option = true;
+    ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, &option);
+  }
 
 //  ms3_debug(true);
   ASSERT_NOT_NULL(ms3);

--- a/tests/prefix.c
+++ b/tests/prefix.c
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
   char *s3region = getenv("S3REGION");
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
+  char *s3noverify = getenv("S3NOVERIFY");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -42,6 +43,12 @@ int main(int argc, char *argv[])
   SKIP_IF_(!s3bucket, "Environemnt variable S3BUCKET missing");
 
   ms3_st *ms3 = ms3_thread_init(s3key, s3secret, s3region, s3host);
+
+  if (s3noverify && !strcmp(s3noverify, "1"))
+  {
+    bool option = true;
+    ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, &option);
+  }
 
 //  ms3_debug(true);
   ASSERT_NOT_NULL(ms3);


### PR DESCRIPTION
* Autoswitch to bucket path instead of bucket domain access method (for IP urls)
* Fixed issue with SSL disabled verification
* Fixed minor leak when base_domain is set
* Add ``S3NOVERIFY`` env var to tests which will disable SSL verification when set to ``1``