### PR TITLE
Fix logic error in ms3_move

### DIFF
--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -4,6 +4,12 @@ Version History
 Version 2.2
 -----------
 
+Version 2.2.1 GA
+^^^^^^^^^^^^^^^^
+
+* Allow compiling with a C++ compiler
+* Fix logic error in :c:func:`ms3_move`
+
 Version 2.2.0 GA (2019-04-23)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/marias3.c
+++ b/src/marias3.c
@@ -81,6 +81,7 @@ ms3_st *ms3_init(const char *s3key, const char *s3secret,
                  const char *base_domain)
 {
   ms3_st *ms3;
+
   if ((s3key == NULL) || (s3secret == NULL))
   {
     return NULL;
@@ -169,7 +170,6 @@ uint8_t ms3_list(ms3_st *ms3, const char *bucket, const char *prefix,
                  ms3_list_st **list)
 {
   uint8_t res = 0;
-  (void) prefix;
 
   if (!ms3 || !bucket || !list)
   {
@@ -255,7 +255,7 @@ uint8_t ms3_move(ms3_st *ms3, const char *source_bucket, const char *source_key,
 
   res = ms3_copy(ms3, source_bucket, source_key, dest_bucket, dest_key);
 
-  if (!res)
+  if (res)
   {
     return res;
   }

--- a/tests/copy.c
+++ b/tests/copy.c
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
   }
 
   ASSERT_EQ_(found_new, 1, "Copied file not found");
-  ASSERT_EQ_(found_orig, 1, "Original file still exists after move");
+  ASSERT_EQ_(found_orig, 0, "Original file still exists after move");
 
   ms3_list_free(list);
 


### PR DESCRIPTION
ms3_move would execute copy and then delete on error rather than delete
on no error. Test was similarly broken.

Fixes #45 