### PR TITLE
Fix several memory issues

### DIFF
--- a/ci-scripts/tsan.sh
+++ b/ci-scripts/tsan.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+export CC=clang
+export CFLAGS="-fsanitize=thread"
+autoreconf -fi
+./configure --enable-debug=yes
+make
+make check 2>/dev/null

--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -8,6 +8,12 @@ Version 3.0.1 GA
 ^^^^^^^^^^^^^^^^
 
 * Improve performance of PUT
+* Fix a few potential pointer arithmatic issues
+* Fix race condition on time generation
+* Added TSAN to ci-scripts
+* Fix minor issues found in cppcheck
+* Stop buffer overrun if the buffer chunk size is set smaller than packet
+* Fix :c:func:`ms3_get` returning random data if a CURL request completely fails
 
 Version 3.0.0 GA (2019-05-13)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/marias3.c
+++ b/src/marias3.c
@@ -227,6 +227,9 @@ uint8_t ms3_get(ms3_st *ms3, const char *bucket, const char *key,
   uint8_t res = 0;
   struct memory_buffer_st buf;
 
+  buf.data = NULL;
+  buf.length = 0;
+
   if (!ms3 || !bucket || !key || !data || !length)
   {
     return MS3_ERR_PARAMETER;

--- a/tests/include.am
+++ b/tests/include.am
@@ -31,6 +31,11 @@ t_large_file_LDADD= src/libmarias3.la
 check_PROGRAMS+= t/large_file
 noinst_PROGRAMS+= t/large_file
 
+t_small_buffer_SOURCES= tests/small_buffer.c
+t_small_buffer_LDADD= src/libmarias3.la
+check_PROGRAMS+= t/small_buffer
+noinst_PROGRAMS+= t/small_buffer
+
 t_prefix_SOURCES= tests/prefix.c
 t_prefix_LDADD= src/libmarias3.la
 check_PROGRAMS+= t/prefix

--- a/tests/longlist.c
+++ b/tests/longlist.c
@@ -44,7 +44,6 @@ const char *test_string = "Another one bites the dust";
 
 static void *put_thread(void *arg)
 {
-  uint8_t res;
   int i;
   struct thread_info *tinfo = arg;
   ms3_st *ms3 = ms3_init(tinfo->s3key, tinfo->s3secret, tinfo->s3region,
@@ -57,6 +56,7 @@ static void *put_thread(void *arg)
 
   for (i = tinfo->start_count; i < tinfo->start_count + 150; i++)
   {
+    uint8_t res;
     char fname[64];
     snprintf(fname, 64, "listtest/list-%d.dat", i);
     res = ms3_put(ms3, tinfo->s3bucket, fname, (const uint8_t *)test_string,
@@ -71,7 +71,6 @@ static void *put_thread(void *arg)
 
 static void *delete_thread(void *arg)
 {
-  uint8_t res;
   int i;
   struct thread_info *tinfo = arg;
   ms3_st *ms3 = ms3_init(tinfo->s3key, tinfo->s3secret, tinfo->s3region,
@@ -84,6 +83,7 @@ static void *delete_thread(void *arg)
 
   for (i = tinfo->start_count; i < tinfo->start_count + 150; i++)
   {
+    uint8_t res;
     char fname[64];
     snprintf(fname, 64, "listtest/list-%d.dat", i);
     res = ms3_delete(ms3, tinfo->s3bucket, fname);


### PR DESCRIPTION
* Fix a few potential pointer arithmatic issues
* Fix race condition on time generation
* Added TSAN to ci-scripts
* Fix minor issues found in cppcheck
* Stop buffer overrun if the buffer chunk size is set smaller than packet
* Fix ms3_get() returning random data if a CURL request completely fails

Fixes mariadb-corporation/libmarias3#55