### PR TITLE
Fix two potential crashes in err msg handling

### DIFF
--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -14,6 +14,8 @@ Version 3.0.1 GA
 * Fix minor issues found in cppcheck
 * Stop buffer overrun if the buffer chunk size is set smaller than packet
 * Fix :c:func:`ms3_get` returning random data if a CURL request completely fails
+* Fix potential crash if the server error message is junk
+* Fix double-free if a server error message is ``NULL``
 
 Version 3.0.0 GA (2019-05-13)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/request.c
+++ b/src/request.c
@@ -30,6 +30,7 @@ static void set_error(ms3_st *ms3, const char *error)
 
   if (!error)
   {
+    ms3->last_error = NULL;
     return;
   }
 
@@ -42,6 +43,7 @@ static void set_error_nocopy(ms3_st *ms3, char *error)
 
   if (!error)
   {
+    ms3->last_error = NULL;
     return;
   }
 

--- a/src/response.c
+++ b/src/response.c
@@ -42,6 +42,11 @@ char *parse_error_message(const char *data, size_t length)
   }
 
   node = xmlDocGetRootElement(doc);
+  if (!node)
+  {
+    xmlFreeDoc(doc);
+    return NULL;
+  }
   // First node is Error
   node = node->xmlChildrenNode;
 


### PR DESCRIPTION
* The error response may not be the XML we expect which would cause a
NULL node to be dereferenced
* Setting the server error message with a NULL message would cause a
double-free