### PR TITLE
Improve linked list memory handling

### DIFF
--- a/docs/api/functions.rst
+++ b/docs/api/functions.rst
@@ -121,7 +121,7 @@ ms3_list()
 
    The list generated is the eqivilent of a recursive directory listing but only has files in it, no entries for directories.
 
-   The resulting list should be freed using :c:func:`ms3_list_free`
+   The list will automatically be freed on the next list/list_dir call or :c:func:`ms3_deinit`
 
    :param ms3: The marias3 object
    :param bucket: The bucket name to use
@@ -156,7 +156,6 @@ Example
      printf("File: %s, size: %ld, tstamp: %ld\n", list_it->key, list_it->length, list_it->created);
      list_it= list_it->next;
    }
-   ms3_list_free(list);
    ms3_deinit(ms3);
 
 ms3_list_dir()
@@ -168,7 +167,7 @@ ms3_list_dir()
 
    The list generated will automatically add the delimiter ``/`` and therefore filter up to the first ``/`` after the prefix. Unlike :c:func:`ms3_list` it includes directory entries. This is the eqivilent of doing a regular directory listing in a current directory (as designated by ``prefix``).
 
-   The resulting list should be freed using :c:func:`ms3_list_free`
+   The list will automatically be freed on the next list/list_dir call or :c:func:`ms3_deinit`
 
    :param ms3: The marias3 object
    :param bucket: The bucket name to use
@@ -182,7 +181,10 @@ ms3_list_free()
 
 .. c:function:: void ms3_list_free(ms3_list_st *list)
 
-   Frees a list generated using :c:func:`ms3_list`
+   .. deprecated:: 3.1.1
+      Now a NULL operation which be removed in 4.0
+
+   A NULL operation, previously free'd :c:func:`ms3_list`, but this is now done internally on :c:func:`ms3_deinit` or when a new list is requested.
 
    :param list: The list to free
 

--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -14,6 +14,8 @@ Version 3.1.1 GA
   * Checks for IP provided domain and turns on list version 1 and path based buckets
   * Any other domain uses list version one and domain based buckets
 
+* Reduced linked list mallocs for :c:func:`ms3_list` and :c:func:`ms3_list_dir`. This also deprecates :c:func:`ms3_list_free`.
+
 Version 3.1.0 GA (2019-06-24)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/request.c
+++ b/src/request.c
@@ -835,27 +835,15 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
     case MS3_CMD_LIST_RECURSIVE:
     case MS3_CMD_LIST:
     {
-      ms3_list_st **list = (ms3_list_st **) ret_ptr;
       char *cont = NULL;
-      parse_list_response((const char *)mem.data, mem.length, list, ms3->list_version,
+      parse_list_response((const char *)mem.data, mem.length, &ms3->list_container, ms3->list_version,
                           &cont);
 
       if (cont)
       {
-        ms3_list_st *list_it;
-        ms3_list_st *append_list = NULL;
         res = execute_request(ms3, cmd, bucket, object, source_bucket, source_object,
                               filter, data, data_size, cont,
-                              &append_list);
-        list_it = *list;
-
-        while (list_it->next != NULL)
-        {
-          list_it = list_it->next;
-        }
-
-        list_it->next = append_list;
-
+                              NULL);
         if (res)
         {
           return res;

--- a/src/response.h
+++ b/src/response.h
@@ -25,4 +25,4 @@
 char *parse_error_message(const char *data, size_t length);
 
 uint8_t parse_list_response(const char *data, size_t length,
-                            ms3_list_st **list, uint8_t list_version, char **continuation);
+                            struct ms3_list_container_st *list_container, uint8_t list_version, char **continuation);

--- a/src/structs.h
+++ b/src/structs.h
@@ -21,6 +21,21 @@
 
 #include "config.h"
 
+struct ms3_pool_alloc_list_st
+{
+  struct ms3_list_st *pool;
+  struct ms3_pool_alloc_list_st *prev;
+};
+
+struct ms3_list_container_st
+{
+  struct ms3_list_st *pool;
+  struct ms3_list_st *start;
+  struct ms3_pool_alloc_list_st *pool_list;
+  struct ms3_list_st *next;
+  size_t pool_free;
+};
+
 struct ms3_st
 {
   char s3key[20];
@@ -37,6 +52,7 @@ struct ms3_st
   bool first_run;
   char *path_buffer;
   char *query_buffer;
+  struct ms3_list_container_st list_container;
 };
 
 struct memory_buffer_st

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -98,8 +98,6 @@ int main(int argc, char *argv[])
     ASSERT_TRUE_(false, "No resuts from list");
   }
 
-  ms3_list_free(list);
-
   // Retry list with V1 API
   list_version = 1;
   list = NULL;
@@ -131,8 +129,6 @@ int main(int argc, char *argv[])
   {
     ASSERT_TRUE_(false, "No resuts from list");
   }
-
-  ms3_list_free(list);
 
   res = ms3_get(ms3, s3bucket, "test/basic_thread.txt", &data, &length);
   ASSERT_EQ_(res, 0, "Result: %u", res);

--- a/tests/basic_host.c
+++ b/tests/basic_host.c
@@ -107,8 +107,6 @@ int main(int argc, char *argv[])
     ASSERT_TRUE_(false, "No resuts from list");
   }
 
-  ms3_list_free(list);
-
   res = ms3_get(ms3, s3bucket, "test/basic_host.txt", &data, &length);
   ASSERT_EQ_(res, 0, "Result: %u", res);
   ASSERT_EQ(length, 26);

--- a/tests/copy.c
+++ b/tests/copy.c
@@ -94,8 +94,6 @@ int main(int argc, char *argv[])
     ASSERT_TRUE_(false, "No resuts from list");
   }
 
-  ms3_list_free(list);
-
   res = ms3_move(ms3, s3bucket, "test/copy_test.txt", s3bucket, "test/moved.txt");
   ASSERT_EQ_(res, 0, "Result: %u", res);
 
@@ -122,8 +120,6 @@ int main(int argc, char *argv[])
 
   ASSERT_EQ_(found_new, 1, "Copied file not found");
   ASSERT_EQ_(found_orig, 0, "Original file still exists after move");
-
-  ms3_list_free(list);
 
   res = ms3_get(ms3, s3bucket, "test/moved.txt", &data, &length);
   ASSERT_EQ_(res, 0, "Result: %u", res);

--- a/tests/custom_malloc.c
+++ b/tests/custom_malloc.c
@@ -129,8 +129,6 @@ int main(int argc, char *argv[])
     ASSERT_TRUE_(false, "No resuts from list");
   }
 
-  ms3_list_free(list);
-
   // Retry list with V1 API
   list_version = 1;
   list = NULL;
@@ -162,8 +160,6 @@ int main(int argc, char *argv[])
   {
     ASSERT_TRUE_(false, "No resuts from list");
   }
-
-  ms3_list_free(list);
 
   res = ms3_get(ms3, s3bucket, "test/custom_malloc.txt", &data, &length);
   ASSERT_EQ_(res, 0, "Result: %u", res);

--- a/tests/list.c
+++ b/tests/list.c
@@ -100,8 +100,6 @@ int main(int argc, char *argv[])
     ASSERT_TRUE_(false, "No resuts from list");
   }
 
-  ms3_list_free(list);
-
   // Retry list with V1 API
   list_version = 1;
   list = NULL;
@@ -133,8 +131,6 @@ int main(int argc, char *argv[])
   {
     ASSERT_TRUE_(false, "No resuts from list");
   }
-
-  ms3_list_free(list);
 
   res = ms3_delete(ms3, s3bucket, "test1/test1.txt");
   ASSERT_EQ_(res, 0, "Result: %u", res);

--- a/tests/longlist.c
+++ b/tests/longlist.c
@@ -182,7 +182,6 @@ int main(int argc, char *argv[])
 
   printf("Found %d items\n", res_count);
   ASSERT_EQ(res_count, 1500);
-  ms3_list_free(list);
 
   // Reattempt with list version 1
   list_version = 1;
@@ -201,7 +200,6 @@ int main(int argc, char *argv[])
 
   printf("V1 Found %d items\n", res_count);
   ASSERT_EQ(res_count, 1500);
-  ms3_list_free(list);
 
   ms3_deinit(ms3);
 

--- a/tests/prefix.c
+++ b/tests/prefix.c
@@ -96,7 +96,6 @@ int main(int argc, char *argv[])
       printf("Bad file count, retrying");
       found_good = false;
       found_bad = false;
-      ms3_list_free(list);
       continue;
     }
     else
@@ -107,7 +106,6 @@ int main(int argc, char *argv[])
 
   ASSERT_EQ_(found_good, 1, "Created file not found");
   ASSERT_EQ_(found_bad, 0, "Filter found file it shouldn't");
-  ms3_list_free(list);
   res = ms3_delete(ms3, s3bucket, "test/prefix.txt");
   ASSERT_EQ(res, 0);
   res = ms3_delete(ms3, s3bucket, "other/prefix.txt");

--- a/tests/snowman.c
+++ b/tests/snowman.c
@@ -98,8 +98,6 @@ int main(int argc, char *argv[])
     ASSERT_TRUE_(false, "No resuts from list");
   }
 
-  ms3_list_free(list);
-
   // Retry list with V1 API
   list_version = 1;
   list = NULL;
@@ -131,8 +129,6 @@ int main(int argc, char *argv[])
   {
     ASSERT_TRUE_(false, "No resuts from list");
   }
-
-  ms3_list_free(list);
 
   res = ms3_get(ms3, s3bucket, "☃/☃.☃", &data, &length);
   ASSERT_EQ_(res, 0, "Result: %u", res);


### PR DESCRIPTION
Now does 2 mallocs per 1024 list entries. Makes ms3_list_free() a NULL
operation (all handled internally now).