### PR TITLE
Use path-stype URLs by default

### DIFF
--- a/src/marias3.c
+++ b/src/marias3.c
@@ -131,6 +131,7 @@ ms3_st *ms3_init(const char *s3key, const char *s3secret,
   ms3->s3key = ms3_cstrdup(s3key);
   ms3->s3secret = ms3_cstrdup(s3secret);
   ms3->region = ms3_cstrdup(region);
+  ms3->protocol_version = 1;
 
   if (base_domain && strlen(base_domain))
   {
@@ -139,25 +140,21 @@ ms3_st *ms3_init(const char *s3key, const char *s3secret,
     if (inet_pton(AF_INET, base_domain, &(sa.sin_addr)))
     {
       ms3->list_version = 1;
-      ms3->protocol_version = 1;
     }
     else if (strcmp(base_domain, "s3.amazonaws.com") == 0)
     {
       ms3->list_version = 2;
-      ms3->protocol_version = 2;
     }
     else
     {
       // Assume that S3-compatible APIs can't support v2 list
       ms3->list_version = 1;
-      ms3->protocol_version = 2;
     }
   }
   else
   {
     ms3->base_domain = NULL;
     ms3->list_version = 2;
-    ms3->protocol_version = 2;
   }
 
   ms3->buffer_chunk_size = READ_BUFFER_DEFAULT_SIZE;


### PR DESCRIPTION
AWS no longer supports the virtual-hosted–style URLs with buckets created
after March 20, 2019. This means that using path-style URLs should be the
default.

This will resolve #76. 