### PR TITLE
include netinet/in.h unconditionally

### DIFF
--- a/src/marias3.c
+++ b/src/marias3.c
@@ -22,9 +22,7 @@
 
 #include <pthread.h>
 #include <arpa/inet.h>
-#ifdef __FreeBSD__
 #include <netinet/in.h>
-#endif
 
 ms3_malloc_callback ms3_cmalloc = (ms3_malloc_callback)malloc;
 ms3_free_callback ms3_cfree = (ms3_free_callback)free;


### PR DESCRIPTION
POSIX says that `struct sockaddr_in` must be defined inside
netinet/in.h

This fixes build on DragonFly BSD and possibly some other platforms
too.