### PR TITLE
Fixed that libmarias3 compiles without warnings/errors on OpenSuse Le…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,9 @@ You will need the following OS environment variables set to run the tests:
 
 The test suite is automatically built along with the library and can be executed with ``make check`` or ``make distcheck``.
 
+Before pushing, please ALWAYS ensure that ``make check`` and ``make distcheck`` works!
+
+
 Credits
 -------
 

--- a/src/assume_role.c
+++ b/src/assume_role.c
@@ -360,10 +360,14 @@ static uint8_t generate_assume_role_request_hash(uri_method_t method, const char
   return 0;
 }
 
-static uint8_t build_assume_role_request_headers(CURL *curl, struct curl_slist **head,
-                                     const char *base_domain, const char* endpoint_type, const char *region, const char *key,
-                                     const char *secret, const char *query, uri_method_t method,
-                                     struct put_buffer_st *post_data, uint8_t protocol_version)
+static uint8_t
+build_assume_role_request_headers(CURL *curl, struct curl_slist **head,
+                                  const char *base_domain,
+                                  const char* endpoint_type,
+                                  const char *region, const char *key,
+                                  const char *secret, const char *query,
+                                  uri_method_t method,
+                                  struct put_buffer_st *post_data)
 {
   uint8_t ret = 0;
   time_t now;
@@ -504,7 +508,9 @@ static uint8_t build_assume_role_request_headers(CURL *curl, struct curl_slist *
   return 0;
 }
 
-uint8_t execute_assume_role_request(ms3_st *ms3, command_t cmd, const uint8_t *data, size_t data_size, char *continuation, void *ret_ptr)
+uint8_t execute_assume_role_request(ms3_st *ms3, command_t cmd,
+                                    const uint8_t *data, size_t data_size,
+                                    char *continuation)
 {
   CURL *curl = NULL;
   struct curl_slist *headers = NULL;
@@ -563,9 +569,10 @@ uint8_t execute_assume_role_request(ms3_st *ms3, command_t cmd, const uint8_t *d
     return res;
   }
 
-  res = build_assume_role_request_headers(curl, &headers, endpoint, endpoint_type, region,
-                                      ms3->s3key, ms3->s3secret, query, method,
-                                      &post_data, ms3->protocol_version);
+  res = build_assume_role_request_headers(curl, &headers, endpoint,
+                                          endpoint_type, region,
+                                          ms3->s3key, ms3->s3secret, query,
+                                          method, &post_data);
 
   if (res)
   {
@@ -647,7 +654,7 @@ uint8_t execute_assume_role_request(ms3_st *ms3, command_t cmd, const uint8_t *d
 
        if (cont && res)
        {
-         res = execute_assume_role_request(ms3, cmd, data, data_size, cont, NULL);
+         res = execute_assume_role_request(ms3, cmd, data, data_size, cont);
          if (res)
          {
            ms3_cfree(cont);
@@ -675,6 +682,13 @@ uint8_t execute_assume_role_request(ms3_st *ms3, command_t cmd, const uint8_t *d
        break;
      }
 
+     case MS3_CMD_LIST:
+     case MS3_CMD_LIST_RECURSIVE:
+     case MS3_CMD_PUT:
+     case MS3_CMD_GET:
+     case MS3_CMD_DELETE:
+     case MS3_CMD_HEAD:
+     case MS3_CMD_COPY:
      default:
      {
        ms3_cfree(mem.data);

--- a/src/assume_role.h
+++ b/src/assume_role.h
@@ -19,4 +19,4 @@
 
 #pragma once
 
-uint8_t execute_assume_role_request(ms3_st *ms3, command_t cmd, const uint8_t *data, size_t data_size, char *continuation, void *ret_ptr);
+uint8_t execute_assume_role_request(ms3_st *ms3, command_t cmd, const uint8_t *data, size_t data_size, char *continuation);

--- a/src/include.am
+++ b/src/include.am
@@ -9,6 +9,10 @@ noinst_HEADERS+= src/structs.h
 noinst_HEADERS+= src/request.h
 noinst_HEADERS+= src/response.h
 noinst_HEADERS+= src/xml.h
+noinst_HEADERS+= src/memory.h
+noinst_HEADERS+= src/sha256.h
+noinst_HEADERS+= src/sha256_i.h
+noinst_HEADERS+= src/assume_role.h
 
 lib_LTLIBRARIES+= src/libmarias3.la
 src_libmarias3_la_SOURCES=

--- a/src/marias3.c
+++ b/src/marias3.c
@@ -619,10 +619,6 @@ uint8_t ms3_set_option(ms3_st *ms3, ms3_set_option_t option, void *value)
 uint8_t ms3_assume_role(ms3_st *ms3)
 {
     uint8_t res = 0;
-    struct memory_buffer_st buf;
-
-    buf.data = NULL;
-    buf.length = 0;
 
     if (!ms3 || !ms3->iam_role)
     {
@@ -632,7 +628,7 @@ uint8_t ms3_assume_role(ms3_st *ms3)
     if (!strstr(ms3->iam_role_arn, ms3->iam_role))
     {
         ms3debug("Lookup IAM role ARN");
-        res = execute_assume_role_request(ms3, MS3_CMD_LIST_ROLE, NULL, 0, NULL, &buf);
+        res = execute_assume_role_request(ms3, MS3_CMD_LIST_ROLE, NULL, 0, NULL);
         if(res)
         {
           return res;
@@ -640,7 +636,7 @@ uint8_t ms3_assume_role(ms3_st *ms3)
 
     }
     ms3debug("Assume IAM role");
-    res = execute_assume_role_request(ms3, MS3_CMD_ASSUME_ROLE, NULL, 0, NULL, &buf);
+    res = execute_assume_role_request(ms3, MS3_CMD_ASSUME_ROLE, NULL, 0, NULL);
 
     return res;
 }

--- a/src/request.c
+++ b/src/request.c
@@ -784,6 +784,7 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
       method = MS3_GET;
       break;
 
+    case MS3_CMD_ASSUME_ROLE:
     default:
       ms3debug("Bad cmd detected");
       ms3_cfree(mem.data);
@@ -944,6 +945,8 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
       break;
     }
 
+    case MS3_CMD_LIST_ROLE:
+    case MS3_CMD_ASSUME_ROLE:
     default:
     {
       ms3_cfree(mem.data);

--- a/src/response.c
+++ b/src/response.c
@@ -454,9 +454,9 @@ uint8_t parse_assume_role_response(const char *data, size_t length, char *assume
         {
           if (!xml_node_name_cmp(credentials, "AccessKeyId"))
           {
-            assume_role_key[0] = '\0';
             struct xml_string *content = xml_node_content(credentials);
             size_t content_length = xml_string_length(content);
+            assume_role_key[0] = '\0';
 
             if (content_length >= 128)
             {
@@ -470,9 +470,9 @@ uint8_t parse_assume_role_response(const char *data, size_t length, char *assume
           }
           if (!xml_node_name_cmp(credentials, "SecretAccessKey"))
           {
-            assume_role_secret[0] = '\0';
             struct xml_string *content = xml_node_content(credentials);
             size_t content_length = xml_string_length(content);
+            assume_role_secret[0] = '\0';
 
             if (content_length >= 1024)
             {
@@ -486,9 +486,9 @@ uint8_t parse_assume_role_response(const char *data, size_t length, char *assume
           }
           if (!xml_node_name_cmp(credentials, "SessionToken"))
           {
-            assume_role_token[0] = '\0';
             struct xml_string *content = xml_node_content(credentials);
             size_t content_length = xml_string_length(content);
+            assume_role_token[0] = '\0';
 
             if (content_length >= 2048)
             {


### PR DESCRIPTION
…ap 15.1

- Added missing headers to src/include.am. This made 'make distcheck' work
  again!
- Removed not used last argument to execute_assume_role_request()
- Added missing ENUM's to switches.  (gcc 7.5.0 on OpenSuse has by default
  [-Werror=switch-enum] enabled, which causes this to fail even if there
  is a default:)
- In src/responce.c fixed that code is after declarations.  This is C,
  not C++!
- Re-indented some very long line