### PR TITLE
Fix ms3_copy for non-alphanumeric characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,10 @@ You will need the following OS environment variables set to run the tests:
 +------------+----------------------------------------------------------+
 | S3HOST     | OPTIONAL hostname for non-AWS S3 service                 |
 +------------+----------------------------------------------------------+
+| S3PORT     | OPTIONAL port for non-AWS S3 service                     |
++------------+----------------------------------------------------------+
+| S3USEHTTP  | Set to ``1`` if the host uses http instead of https      |
++------------+----------------------------------------------------------+
 | S3NOVERIFY | Set to ``1`` if the host should not use SSL verification |
 +------------+----------------------------------------------------------+
 
@@ -51,7 +55,8 @@ Credits
 
 The libMariaS3 authors are:
 
-* `Andrew (LinuxJedi) Hutchings <mailto:linuxjedi@mariadb.com>`_
+* `Andrew (LinuxJedi) Hutchings <mailto:andrew@linuxjedi.co.uk>`_
+  - Starting with this commit, all my contributions are under the 3-clause BSD license.
 * `Sergei Golubchik <mailto:sergei@mariadb.com>`_
 * `Markus Mäkelä <markus.makela@mariadb.com>`_
 

--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -4,6 +4,11 @@ Version History
 Version 3.1
 -----------
 
+Version 3.1.3 GA
+^^^^^^^^^^^^^^^^
+
+* Fix :c:func:`ms3_copy` not working correctly with non-alphanumeric characters (also affected :c:func:`ms3_move`)
+
 Version 3.1.2 GA
 ^^^^^^^^^^^^^^^^
 

--- a/src/request.c
+++ b/src/request.c
@@ -466,9 +466,15 @@ static uint8_t build_request_headers(CURL *curl, struct curl_slist **head,
 
   if (source_bucket)
   {
+    char *bucket_escape;
+    char *key_escape;
+    bucket_escape = curl_easy_escape(curl, source_bucket, (int)strlen(source_bucket));
+    key_escape = curl_easy_escape(curl, source_key, (int)strlen(source_key));
     snprintf(headerbuf, sizeof(headerbuf), "x-amz-copy-source:/%s/%s",
-             source_bucket, source_key);
+             bucket_escape, key_escape);
     headers = curl_slist_append(headers, headerbuf);
+    ms3_cfree(bucket_escape);
+    ms3_cfree(key_escape);
   }
 
   // Date/time header

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -55,6 +57,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug();

--- a/tests/basic_host.c
+++ b/tests/basic_host.c
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -57,7 +59,6 @@ int main(int argc, char *argv[])
     s3host = (char *)default_host;
   }
 
-
   ms3_library_init();
   ms3 = ms3_init(s3key, s3secret, s3region, s3host);
   protocol_version = 2;
@@ -66,6 +67,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug();

--- a/tests/custom_malloc.c
+++ b/tests/custom_malloc.c
@@ -70,6 +70,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -86,6 +88,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug(true);

--- a/tests/large_file.c
+++ b/tests/large_file.c
@@ -36,6 +36,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
   memset(test_string, 'a', 64 * 1024 * 1024);
 
   (void) argc;
@@ -52,6 +54,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug(true);

--- a/tests/list.c
+++ b/tests/list.c
@@ -36,6 +36,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -51,6 +53,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug();

--- a/tests/prefix.c
+++ b/tests/prefix.c
@@ -37,6 +37,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -51,6 +53,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug(true);

--- a/tests/small_buffer.c
+++ b/tests/small_buffer.c
@@ -36,6 +36,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
   memset(test_string, 'a', 64 * 1024);
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
@@ -52,6 +54,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug(true);

--- a/tests/snowman.c
+++ b/tests/snowman.c
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
   char *s3bucket = getenv("S3BUCKET");
   char *s3host = getenv("S3HOST");
   char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
 
   SKIP_IF_(!s3key, "Environemnt variable S3KEY missing");
   SKIP_IF_(!s3secret, "Environemnt variable S3SECRET missing");
@@ -55,6 +57,17 @@ int main(int argc, char *argv[])
   if (s3noverify && !strcmp(s3noverify, "1"))
   {
     ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
 //  ms3_debug();


### PR DESCRIPTION
The S3 API specification states that x-amz-copy-source should be
urlencoded. libmarias3 wasn't doing this but Amazon's S3 implementation
appeared to be forgiving enough that it didn't matter. When using
compatible APIs such as MinIO this requirement became stricter.

The code now urlencodes the source path for ms3_copy / ms3_move.

In addition this patch adds support for MinIO in the test suite by
adding environment variables for port and disabling https.