### PR TITLE
MCOL-4386

### DIFF
--- a/libmarias3/marias3.h
+++ b/libmarias3/marias3.h
@@ -107,6 +107,11 @@ MS3_API
 uint8_t ms3_init_assume_role(ms3_st *ms3, const char *iam_role, const char *sts_endpoint, const char *sts_region);
 
 MS3_API
+uint8_t ms3_ec2_set_cred(ms3_st *ms3, const char *iam_role,
+                     const char *s3key, const char *s3secret,
+                     const char *token);
+
+MS3_API
 uint8_t ms3_set_option(ms3_st *ms3, ms3_set_option_t option, void *value);
 
 MS3_API

--- a/src/marias3.c
+++ b/src/marias3.c
@@ -264,6 +264,28 @@ uint8_t ms3_init_assume_role(ms3_st *ms3, const char *iam_role, const char *sts_
   return ret;
 }
 
+uint8_t ms3_ec2_set_cred(ms3_st *ms3, const char *iam_role,
+                     const char *s3key, const char *s3secret,
+                     const char *token)
+{
+  uint8_t ret=0;
+
+  if (iam_role == NULL || token == NULL || s3key == NULL || s3secret == NULL)
+  {
+      return MS3_ERR_PARAMETER;
+  }
+  ms3->iam_role = ms3_cstrdup(iam_role);
+  ms3->role_key = ms3_cstrdup(s3key);
+  ms3->role_secret = ms3_cstrdup(s3secret);
+  ms3->role_session_token = ms3_cstrdup(token);
+  ms3->sts_endpoint = NULL;
+  ms3->sts_region = NULL;
+  ms3->iam_endpoint = NULL;
+  ms3->iam_role_arn = NULL;
+
+  return ret;
+}
+
 static void list_free(ms3_st *ms3)
 {
   ms3_list_st *list = ms3->list_container.start;
@@ -303,13 +325,25 @@ void ms3_deinit(ms3_st *ms3)
   if (ms3->iam_role)
   {
     ms3_cfree(ms3->iam_role);
-    ms3_cfree(ms3->iam_endpoint);
-    ms3_cfree(ms3->sts_endpoint);
-    ms3_cfree(ms3->sts_region);
-    ms3_cfree(ms3->iam_role_arn);
     ms3_cfree(ms3->role_key);
     ms3_cfree(ms3->role_secret);
     ms3_cfree(ms3->role_session_token);
+  }
+  if(ms3->iam_endpoint)
+  {
+    ms3_cfree(ms3->iam_endpoint);
+  }
+  if(ms3->sts_endpoint)
+  {
+    ms3_cfree(ms3->sts_endpoint);
+  }
+  if(ms3->sts_region)
+  {
+    ms3_cfree(ms3->sts_region);
+  }
+  if(ms3->iam_role_arn)
+  {
+    ms3_cfree(ms3->iam_role_arn);
   }
   curl_easy_cleanup(ms3->curl);
   ms3_cfree(ms3->last_error);


### PR DESCRIPTION
Add ability to set temp credentials for IAM role and temp credentials.
MCOL-4386 requires ability to set the IAM Role and temp credentials provided from an EC2 instance metadata instead of being requested from STS.