### PR TITLE
Define RTLD_DEFAULT if not defined

### DIFF
--- a/src/marias3.c
+++ b/src/marias3.c
@@ -33,6 +33,9 @@ ms3_calloc_callback ms3_ccalloc = (ms3_calloc_callback)calloc;
 
 /* Thread locking code for OpenSSL < 1.1.0 */
 #include <dlfcn.h>
+#ifndef RTLD_DEFAULT
+#define RTLD_DEFAULT ((void *)0)
+#endif
 static pthread_mutex_t *mutex_buf = NULL;
 #define CRYPTO_LOCK 1
 static void (*openssl_set_id_callback)(unsigned long (*func)(void));


### PR DESCRIPTION
It was noticed with mariadb-10.5 builds in Debian that libmarias3 failed
to build on platform kFreeBSD due to missing RTLD_DEFAULT. This fix has
been in Debian since February and has proven to work as intended.

Once this is merged upstream, we can stop carrying the downsteam patch
https://salsa.debian.org/mariadb-team/mariadb-10.5/-/blob/master/debian/patches/rtld_default-kfreebsd.patch