### PR TITLE
Fix MS3_OPT_FORCE_PROTOCOL_VERSION

### DIFF
--- a/src/marias3.c
+++ b/src/marias3.c
@@ -617,7 +617,7 @@ uint8_t ms3_set_option(ms3_st *ms3, ms3_set_option_t option, void *value)
         return MS3_ERR_PARAMETER;
       }
 
-      ms3->list_version = protocol_version;
+      ms3->protocol_version = protocol_version;
       break;
     }
 


### PR DESCRIPTION
The wrong variable was being updated.

I am contributing the new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.