### PR TITLE
MCOL-5177

### DIFF
--- a/libmarias3/marias3.h
+++ b/libmarias3/marias3.h
@@ -70,6 +70,7 @@ enum ms3_error_code_t
   MS3_ERR_SERVER,
   MS3_ERR_TOO_BIG,
   MS3_ERR_AUTH_ROLE,
+  MS3_ERR_ENDPOINT,
   MS3_ERR_MAX // Always the last error
 };
 

--- a/src/request.c
+++ b/src/request.c
@@ -848,6 +848,18 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
   ms3debug("Response code: %ld", response_code);
 
+  if (response_code == 301)
+  {
+    char *message = parse_error_message((char *)mem.data, mem.length);
+
+    if (message)
+    {
+      ms3debug("Response message: %s", message);
+    }
+
+    set_error_nocopy(ms3, message);
+    res = MS3_ERR_ENDPOINT;
+  }
   if (response_code == 404)
   {
     char *message = parse_error_message((char *)mem.data, mem.length);


### PR DESCRIPTION
Mismatch bucket and endpoint AWS returning HTTP response code 301. SM needs this error reported.