### PR TITLE
Add custom callback mechanism

### DIFF
--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -49,6 +49,8 @@ Constants
    * ``MS3_OPT_BUFFER_CHUNK_SIZE`` - Set the chunk size in bytes for the receive buffer. Default is 1MB. If you are receiving a large file a realloc will have to happen every time the buffer is full. For performance reasons you may want to increase the size of this buffer to reduce the reallocs and associated memory copies. The ``value`` parameter of :c:func:`ms3_set_option` should be a pointer to a :c:type:`size_t` greater than 1.
    * ``MS3_OPT_FORCE_LIST_VERSION`` - An internal option for the regression suite only. The ``value`` parameter of :c:func:`ms3_set_option` should be a pointer to a :c:type:`uint8_t` of value ``1`` or ``2``
    * ``MS3_OPT_FORCE_PROTOCOL_VERSION`` - Set to 1 to force talking to the S3 server using version 1 of the List Bucket API, this is for S3 compatible servers. Set to 2 to force talking to the S3 server version 2 of the List Bucket API. This is for use when the autodetect bsaed on providing a base_domain does the wrong thing. The ``value`` parameter of :c:func:`ms3_set_option` should be a pointer to a :c:type:`uint8_t` of value ``1`` or ``2``
+   * ``MS3_OPT_READ_CB`` - Custom read callback for :c:func:`ms3_get`. The ``value`` parameter of :c:func:`ms3_set_option` should be a :c:type:`ms3_read_callback` function.
+   * ``MS3_OPT_USER_DATA`` - User data for the custom read callback. The ``value`` parameter of :c:func:`ms3_set_option` is the pointer that will be passed as the ``userdata`` argument of the callback.
 
 Built-In Types
 ==============

--- a/libmarias3/marias3.h
+++ b/libmarias3/marias3.h
@@ -55,6 +55,12 @@ typedef void *(*ms3_realloc_callback)(void *ptr, size_t size);
 typedef char *(*ms3_strdup_callback)(const char *str);
 typedef void *(*ms3_calloc_callback)(size_t nmemb, size_t size);
 
+/** The callback function for MS3_OPT_READ_CB. The function and the user data
+ * set with MS3_OPT_USER_DATA are passed to Curl. For more information, refer
+ * to CURLOPT_WRITE_FUNCTION. */
+typedef size_t (*ms3_read_callback)(void *buffer, size_t size,
+                                    size_t nitems, void *userdata);
+
 enum ms3_error_code_t
 {
   MS3_ERR_NONE,
@@ -83,6 +89,8 @@ enum ms3_set_option_t
   MS3_OPT_BUFFER_CHUNK_SIZE,
   MS3_OPT_FORCE_LIST_VERSION,
   MS3_OPT_FORCE_PROTOCOL_VERSION,
+  MS3_OPT_READ_CB,
+  MS3_OPT_USER_DATA,
   MS3_OPT_PORT_NUMBER
 };
 

--- a/src/marias3.c
+++ b/src/marias3.c
@@ -449,15 +449,23 @@ uint8_t ms3_get(ms3_st *ms3, const char *bucket, const char *key,
   buf.data = NULL;
   buf.length = 0;
 
-  if (!ms3 || !bucket || !key || key[0] == '\0' || !data || !length)
+  if (!ms3 || !bucket || !key || key[0] == '\0')
+  {
+    return MS3_ERR_PARAMETER;
+  }
+  else if (!ms3->read_cb && (!data || !length))
   {
     return MS3_ERR_PARAMETER;
   }
 
   res = execute_request(ms3, MS3_CMD_GET, bucket, key, NULL, NULL, NULL, NULL, 0,
                         NULL, &buf);
-  *data = buf.data;
-  *length = buf.length;
+  if (!ms3->read_cb)
+  {
+    *data = buf.data;
+    *length = buf.length;
+  }
+
   return res;
 }
 
@@ -634,6 +642,24 @@ uint8_t ms3_set_option(ms3_st *ms3, ms3_set_option_t option, void *value)
       ms3->port = port_number;
       break;
     }
+
+    case MS3_OPT_READ_CB:
+    {
+      if (!value)
+      {
+        return MS3_ERR_PARAMETER;
+      }
+
+      ms3->read_cb = value;
+      break;
+    }
+
+    case MS3_OPT_USER_DATA:
+    {
+      ms3->user_data = value;
+      break;
+    }
+
     default:
       return MS3_ERR_PARAMETER;
   }

--- a/src/request.c
+++ b/src/request.c
@@ -840,6 +840,7 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&mem);
   }
 
+  curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, ms3->buffer_chunk_size);
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
   curl_res = curl_easy_perform(curl);

--- a/src/request.c
+++ b/src/request.c
@@ -829,9 +829,18 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
   if (ms3->port)
     curl_easy_setopt(curl, CURLOPT_PORT, (long)ms3->port);
 
+  if (ms3->read_cb && cmd == MS3_CMD_GET)
+  {
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ms3->read_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, ms3->user_data);
+  }
+  else
+  {
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, body_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&mem);
+  }
+
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, body_callback);
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&mem);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
   curl_res = curl_easy_perform(curl);
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -64,6 +64,8 @@ struct ms3_st
   bool first_run;
   char *path_buffer;
   char *query_buffer;
+  void *read_cb;
+  void *user_data;
   struct ms3_list_container_st list_container;
 };
 

--- a/tests/include.am
+++ b/tests/include.am
@@ -67,3 +67,7 @@ t_list_LDADD= src/libmarias3.la
 check_PROGRAMS+= t/list
 noinst_PROGRAMS+= t/list
 
+t_read_cb_SOURCES= tests/read_cb.c
+t_read_cb_LDADD= src/libmarias3.la
+check_PROGRAMS+= t/read_cb
+noinst_PROGRAMS+= t/read_cb

--- a/tests/read_cb.c
+++ b/tests/read_cb.c
@@ -1,5 +1,5 @@
 /* vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * Copyright 2019 MariaDB Corporation Ab. All rights reserved.
+ * Copyright 2023 MariaDB Corporation Ab. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/read_cb.c
+++ b/tests/read_cb.c
@@ -1,0 +1,110 @@
+/* vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
+ * Copyright 2019 MariaDB Corporation Ab. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+#include <yatl/lite.h>
+#include <libmarias3/marias3.h>
+
+#define NUM_BYTES 64 * 1024
+
+/* Tests basic GET with a custom read callback */
+
+static size_t read_cb(void *buf, size_t size, size_t nitems, void *userdata)
+{
+    char** dat = (char**)userdata;
+    char* ptr = *dat;
+    memcpy(ptr, buf, size * nitems);
+    ptr += size * nitems;
+    *dat = ptr;
+    return nitems * size;
+}
+
+int main(int argc, char *argv[])
+{
+  int res;
+  uint8_t *data;
+  size_t length;
+  ms3_st *ms3;
+  char *test_string = malloc(NUM_BYTES);
+  char *dest = malloc(NUM_BYTES);
+  char* userdata = dest;
+  char *s3key = getenv("S3KEY");
+  char *s3secret = getenv("S3SECRET");
+  char *s3region = getenv("S3REGION");
+  char *s3bucket = getenv("S3BUCKET");
+  char *s3host = getenv("S3HOST");
+  char *s3noverify = getenv("S3NOVERIFY");
+  char *s3usehttp = getenv("S3USEHTTP");
+  char *s3port = getenv("S3PORT");
+
+  SKIP_IF_(!s3key, "Environment variable S3KEY missing");
+  SKIP_IF_(!s3secret, "Environment variable S3SECRET missing");
+  SKIP_IF_(!s3region, "Environment variable S3REGION missing");
+  SKIP_IF_(!s3bucket, "Environment variable S3BUCKET missing");
+
+  (void) argc;
+  (void) argv;
+
+  memset(test_string, 'a', NUM_BYTES);
+  memset(dest, 'b', NUM_BYTES);
+
+  ms3_library_init();
+  ms3 = ms3_init(s3key, s3secret, s3region, s3host);
+
+  if (s3noverify && !strcmp(s3noverify, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_DISABLE_SSL_VERIFY, NULL);
+  }
+
+  if (s3usehttp && !strcmp(s3usehttp, "1"))
+  {
+    ms3_set_option(ms3, MS3_OPT_USE_HTTP, NULL);
+  }
+
+  if (s3port)
+  {
+    int port = atol(s3port);
+    ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
+  }
+
+  ASSERT_NOT_NULL(ms3);
+
+  res = ms3_put(ms3, s3bucket, "test/read_cb.dat",
+                (const uint8_t *)test_string,
+                NUM_BYTES);
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  res = ms3_set_option(ms3, MS3_OPT_READ_CB, read_cb);
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  res = ms3_set_option(ms3, MS3_OPT_USER_DATA, &userdata);
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  length = 0;
+  data = 0;
+  res = ms3_get(ms3, s3bucket, "test/read_cb.dat", &data, &length);
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  ASSERT_EQ(data, 0);
+  ASSERT_EQ(length, 0);
+  ASSERT_EQ(memcmp(test_string, dest, NUM_BYTES), 0);
+  res = ms3_delete(ms3, s3bucket, "test/read_cb.dat");
+  ASSERT_EQ_(res, 0, "Result: %u", res);
+  free(test_string);
+  free(dest);
+  ms3_free(data);
+  ms3_deinit(ms3);
+  ms3_library_deinit();
+  return 0;
+}


### PR DESCRIPTION
Being able to process data in smaller chunks while it's being read by curl would allow the library to be used with larger files without having to first read it into memory.

Also passed the `MS3_OPT_BUFFER_CHUNK_SIZE` to curl via [CURLOPT_BUFFERSIZE](https://curl.se/libcurl/c/CURLOPT_BUFFERSIZE.html).