### PR TITLE
Put ms3_get_content_type() behind ifdef

### DIFF
--- a/src/marias3.c
+++ b/src/marias3.c
@@ -230,7 +230,9 @@ ms3_st *ms3_init(const char *s3key, const char *s3secret,
   ms3->sts_region = NULL;
   ms3->iam_role_arn = NULL;
 
+#ifdef HAVE_NEW_CURL_API
   ms3->content_type_in = NULL;
+#endif
   ms3->content_type_out = NULL;
 
   return ms3;
@@ -750,7 +752,7 @@ void ms3_set_content_type(ms3_st *ms3, const char *content_type)
 
     ms3->content_type_out = content_type;
 }
-
+#ifdef HAVE_NEW_CURL_API
 const char *ms3_get_content_type(ms3_st *ms3)
 {
     if (!ms3)
@@ -759,3 +761,4 @@ const char *ms3_get_content_type(ms3_st *ms3)
     }
     return ms3->content_type_in;
 }
+#endif

--- a/src/request.c
+++ b/src/request.c
@@ -717,9 +717,11 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
                         void *ret_ptr)
 {
   CURL *curl = NULL;
+#ifdef HAVE_NEW_CURL_API
   CURLHcode curl_hret;
-  struct curl_slist *headers = NULL;
   struct curl_header *content_type_in;
+#endif
+  struct curl_slist *headers = NULL;
   uint8_t res = 0;
   struct memory_buffer_st mem;
   uri_method_t method;
@@ -883,12 +885,14 @@ uint8_t execute_request(ms3_st *ms3, command_t cmd, const char *bucket,
 
     return MS3_ERR_REQUEST_ERROR;
   }
+#ifdef HAVE_NEW_CURL_API
   curl_hret = curl_easy_header(curl, "content-type", 0, CURLH_HEADER, -1,
                                &content_type_in);
   if (!curl_hret && content_type_in)
   {
       ms3->content_type_in = content_type_in->value;
   }
+#endif
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
   ms3debug("Response code: %ld", response_code);
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -70,7 +70,9 @@ struct ms3_st
   void *read_cb;
   void *user_data;
   const char *content_type_out;
+#ifdef HAVE_NEW_CURL_API
   const char *content_type_in;
+#endif
   struct ms3_list_container_st list_container;
 };
 

--- a/tests/content_type.c
+++ b/tests/content_type.c
@@ -22,6 +22,15 @@
 
 /* Tests basic put, list, get, status, delete using the thread calls */
 
+#ifndef HAVE_NEW_CURL_API
+int main(int argc, char *argv[])
+{
+  (void) argc;
+  (void) argv;
+  SKIP_IF_(1, "Requires HAVE_NEW_CURL_API to be defined");
+  return 0;
+}
+#else
 int main(int argc, char *argv[])
 {
   int res;
@@ -146,3 +155,4 @@ int main(int argc, char *argv[])
   ms3_library_deinit();
   return 0;
 }
+#endif


### PR DESCRIPTION
It only works with Curl 7.83.0 onwards. It can be refactored to use the older header API which is callback based at a later date.