### PR TITLE
Fix ms3_get_content_type()

### DIFF
--- a/docs/api/functions.rst
+++ b/docs/api/functions.rst
@@ -410,9 +410,10 @@ ms3_get_content_type()
 
 .. c:function:: const char *ms3_get_content_type(ms3_st *ms3)
 
-   Gets the ``Content-Type:`` header for the previous response from the S3 server.
-   This will automatically freed as part of the request handling, it will lose
-   scope on the next request and should not be freed by the application.
+   Gets the ``Content-Type:`` header for the previous GET request  response
+   from the S3 server.
+   The memory for this is part of the :c:type:`ms3_st` object and should not be
+   freed by the application. The contents will be reset on each GET request.
 
    :param ms3: The marias3 object
    :param content_type: The mime type for the previous request

--- a/src/marias3.c
+++ b/src/marias3.c
@@ -752,7 +752,7 @@ void ms3_set_content_type(ms3_st *ms3, const char *content_type)
 
     ms3->content_type_out = content_type;
 }
-#ifdef HAVE_NEW_CURL_API
+
 const char *ms3_get_content_type(ms3_st *ms3)
 {
     if (!ms3)
@@ -761,4 +761,3 @@ const char *ms3_get_content_type(ms3_st *ms3)
     }
     return ms3->content_type_in;
 }
-#endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -70,9 +70,7 @@ struct ms3_st
   void *read_cb;
   void *user_data;
   const char *content_type_out;
-#ifdef HAVE_NEW_CURL_API
-  const char *content_type_in;
-#endif
+  char content_type_in[128]; // max length allowed for mime types
   struct ms3_list_container_st list_container;
 };
 

--- a/tests/content_type.c
+++ b/tests/content_type.c
@@ -22,15 +22,6 @@
 
 /* Tests basic put, list, get, status, delete using the thread calls */
 
-#ifndef HAVE_NEW_CURL_API
-int main(int argc, char *argv[])
-{
-  (void) argc;
-  (void) argv;
-  SKIP_IF_(1, "Requires HAVE_NEW_CURL_API to be defined");
-  return 0;
-}
-#else
 int main(int argc, char *argv[])
 {
   int res;
@@ -75,7 +66,7 @@ int main(int argc, char *argv[])
 
   if (s3port)
   {
-    int port = atol(s3port);
+    int port = atoi(s3port);
     ms3_set_option(ms3, MS3_OPT_PORT_NUMBER, &port);
   }
 
@@ -155,4 +146,3 @@ int main(int argc, char *argv[])
   ms3_library_deinit();
   return 0;
 }
-#endif


### PR DESCRIPTION
Now uses the legacy curl method of header callbacks. #ifdef guard removed.

Fixes #124 