### PR TITLE
snprint still needed regardless of pragmas

### DIFF
--- a/src/assume_role.c
+++ b/src/assume_role.c
@@ -160,8 +160,10 @@ static uint8_t build_assume_role_request_uri(CURL *curl, const char *base_domain
 # pragma GCC diagnostic ignored "-Wpragmas"
 # pragma GCC diagnostic ignored "-Wunknown-warning-option"
 # pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
     snprintf(uri_buffer, MAX_URI_LENGTH - 1, "%s://%s/?%s", protocol,
              domain, query);
+#ifdef __GNUC__
 # pragma GCC diagnostic pop
 #endif
   }


### PR DESCRIPTION
Error in the previous was the #ifdef __GNUC__ mean there is no snprintf in other implementations.

Constrain the #ifdef __GNUC__ defines to the
pragma clauses.