### PR TITLE
MDEV-34937 s3 engine no longer functional on non-gcc builds

### DIFF
--- a/src/assume_role.c
+++ b/src/assume_role.c
@@ -123,7 +123,6 @@ static uint8_t build_assume_role_request_uri(CURL *curl, const char *base_domain
 {
   char uri_buffer[MAX_URI_LENGTH];
   const char *domain;
-  const uint8_t path_parts = 10; // "https://" + "." + "/"
   const char *http_protocol = "http";
   const char *https_protocol = "https";
   const char *protocol;
@@ -148,22 +147,9 @@ static uint8_t build_assume_role_request_uri(CURL *curl, const char *base_domain
 
   if (query)
   {
-    if (path_parts + strlen(domain) + strlen(query) >= MAX_URI_LENGTH - 1)
-    {
+    if (snprintf(uri_buffer, MAX_URI_LENGTH, "%s://%s/?%s", protocol,
+             domain, query) >= MAX_URI_LENGTH)
       return MS3_ERR_URI_TOO_LONG;
-    }
-
-// The check for this is above, but GCC 14.2 still says there could be a
-// truncation
-#ifdef __GNUC__
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wpragmas"
-# pragma GCC diagnostic ignored "-Wunknown-warning-option"
-# pragma GCC diagnostic ignored "-Wformat-truncation"
-    snprintf(uri_buffer, MAX_URI_LENGTH - 1, "%s://%s/?%s", protocol,
-             domain, query);
-# pragma GCC diagnostic pop
-#endif
   }
   else
   {


### PR DESCRIPTION
snprintf already includes a mechanism to prevent writing too much into a buffer. The maximum length snprintf will
write is its size. Per manual of snprintf, an insufficient buffer will result in the function returning size or more.
    
The common case is this buffer isn't too much. If the limit is reached, return the MS3_ERR_URI_TOO_LONG like like before.
    
With this in place, no pre-processor warning handling is needed.